### PR TITLE
add --noconfirm to pacman invocation

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -2,8 +2,8 @@
 
 FROM archlinux
 
-RUN yes | pacman -Syu
-RUN yes | pacman -Sy git libseccomp wget gcc pkg-config parallel time
+RUN pacman -Syu --noconfirm
+RUN pacman -Sy --noconfirm git libseccomp wget gcc pkg-config parallel time
 
 # Download an initial version of Go
 RUN wget "https://go.dev/dl/go1.20.4.linux-amd64.tar.gz" && \


### PR DESCRIPTION
Doing yes | pacman -Syu fails as some command reads the output expecting a number, but y is invalid.

Fixes #1 