### PR TITLE
Wasmer llvm

### DIFF
--- a/docker/target.Dockerfile
+++ b/docker/target.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1-experimental
 
-FROM ubuntu:24.04 AS base
+FROM ubuntu:22.04 AS base
 
 RUN apt update && \
   apt install -y \
@@ -13,7 +13,70 @@ RUN apt update && \
   libc6-dbg \
   libabsl-dev \
   curl \
-  golang
+  golang \
+  git \
+  wget \
+  gcc \
+  g++ \
+  pkg-config \
+  parallel \
+  time \
+  cmake \
+  ccache \
+  libprotoc-dev \
+  protobuf-compiler \
+  build-essential \
+  libssl-dev \
+  python3 \
+  python3-pip \
+  clang \
+  lld
+
+# Install LLVM 13
+RUN apt install -y \
+  llvm-13 \
+  llvm-13-dev \
+  llvm-13-runtime \
+  clang-13 \
+  libclang-13-dev \
+  liblld-13-dev
+
+# Set up LLVM environment variables
+ENV LLVM_SYS_130_PREFIX=/usr/lib/llvm-13
+ENV LLVM_DIR=/usr/lib/llvm-13
+ENV PATH=/usr/lib/llvm-13/bin:$PATH
+
+# Install Rust to build Wasmer
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:$PATH"
+
+# Clone and build Wasmer 2.3.0 with LLVM support
+WORKDIR /tmp
+RUN git clone https://github.com/wasmerio/wasmer.git && \
+  cd wasmer && \
+  git checkout 2.3.0 && \
+  cargo build --release --features llvm,singlepass,cranelift
+
+# Build Wasmer C API with LLVM support
+WORKDIR /tmp/wasmer/lib/c-api
+RUN cargo build --release --features llvm,singlepass,cranelift 
+
+WORKDIR /tmp/wasmer
+RUN make package-capi
+
+# Install Wasmer C API system-wide
+RUN cd package && \
+  cp lib/* /usr/local/lib/ && \
+  cp include/* /usr/local/include/ && \
+  ldconfig
+
+# Set up Wasmer environment variables
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV CGO_LDFLAGS="-L/usr/local/lib -lwasmer"
+ENV CGO_CFLAGS="-I/usr/local/include"
+
+# Clean up temporary build files 
+RUN rm -rf /tmp/wasmer 
 
 # Install wasmer go pkg
 RUN mkdir t && \

--- a/proxy/wasm/rpc/wasmer/wasmer.go
+++ b/proxy/wasm/rpc/wasmer/wasmer.go
@@ -25,7 +25,15 @@ func NewWasmerRuntime(rpcAPI wasmrpc.RPCAPI) *WasmerRuntime {
 	// binaries
 	// TODO: try this https://github.com/wasmerio/wasmer-go/issues/222
 	//	cfg := wasmer.NewConfig().UseLLVMCompiler()
-	cfg := wasmer.NewConfig().UseCraneliftCompiler()
+	var cfg *wasmer.Config
+	if !wasmer.IsCompilerAvailable(wasmer.LLVM) {
+		db.DPrintf(db.ERROR, "LLVM compiler not available, using Cranelift compiler instead")
+		db.DPrintf(db.WASMRT_ERR, "LLVM compiler not available, using Cranelift compiler instead")
+		cfg = wasmer.NewConfig().UseCraneliftCompiler()
+	} else {
+		db.DPrintf(db.WASMRT, "Using LLVM compiler")
+		cfg = wasmer.NewConfig().UseLLVMCompiler()
+	}
 	engine := wasmer.NewEngineWithConfig(cfg)
 	return &WasmerRuntime{
 		rpcAPI:       rpcAPI,

--- a/proxy/wasm/wasm_test.go
+++ b/proxy/wasm/wasm_test.go
@@ -23,7 +23,7 @@ var wasmScript string
 var cossimBootScript string
 
 func init() {
-	flag.StringVar(&wasmScript, "wasm_script", "/home/arielck/sigmaos/rs/wasm/hello-wasm/target/wasm32-unknown-unknown/release/hello_wasm.wasm", "path to WASM script")
+	flag.StringVar(&wasmScript, "wasm_script", "/home/arielck/sigmaos/rs/wasm/hello_wasm/target/wasm32-unknown-unknown/release/hello_wasm.wasm", "path to WASM script")
 	flag.StringVar(&cossimBootScript, "cossim_boot_script", "/home/arielck/sigmaos/rs/wasm/cossim_boot/target/wasm32-unknown-unknown/release/cossim_boot.wasm", "path to WASM script")
 }
 


### PR DESCRIPTION
the versioning is a bit tricky: wasmer-go latest version 1.0.4 is only compatible with old wasmer 2.x which are only compatible with old llvm 13 which needed ubuntu 22 

if we really need a newer llvm we fork wasmer-go modify it to use new wasmer api or use wasmedge 
